### PR TITLE
Gas Optimization for DeployNFT

### DIFF
--- a/packages/smartcontract/.gitignore
+++ b/packages/smartcontract/.gitignore
@@ -9,7 +9,7 @@ out/
 /broadcast/*
 
 # Docs
-docs/
+# docs/
 
 # Dotenv file
 .env

--- a/packages/smartcontract/docs/01_DeployNFT_Gas_Optimization.md
+++ b/packages/smartcontract/docs/01_DeployNFT_Gas_Optimization.md
@@ -1,0 +1,51 @@
+Okay, here are the gas optimization suggestions for `NFTLaunchManager.sol` broken down into a task list:
+
+**Task List: Gas Optimization for `NFTLaunchManager.sol`**
+
+**Phase 1: Easy Wins / Good Practices**
+
+*   [ ]  **Task 1: Verify Compiler Optimization Settings:**
+    *   Check your framework's configuration (e.g., `hardhat.config.js`, `foundry.toml`).
+    *   Ensure the Solidity optimizer is enabled.
+    *   Ensure the `runs` parameter is set to a reasonable value (e.g., 200 or higher).
+*   [ ] **Task 2: Remove Redundant Array Check in `deployNFT`:**
+    *   Locate the `if (_userContracts[msg.sender].length == 0)` block in `deployNFT`.
+    *   Remove this `if` statement entirely. The `push` operation handles empty arrays correctly.
+*   [ ] **Task 3 (Optional - Minor Impact): Cache Storage Read in `deployNFT`:**
+    *   In `deployNFT`, read `_userContractAmount[msg.sender]` into a local `uint256 currentAmount` variable at the beginning.
+    *   Use `currentAmount` in the `string.concat` call.
+    *   Update the amount using `_userContractAmount[msg.sender] = currentAmount + 1;`.
+
+**Phase 2: Contract-Level Optimization**
+
+*   [ ] **Task 4: Analyze and Optimize `NFTLauncher.sol`:**
+    *   Review the code within `NFTLauncher.sol`.
+    *   Identify and remove any unused functions, variables, or inherited contracts.
+    *   Simplify logic within the `NFTLauncher` constructor.
+    *   Look for general gas optimizations within `NFTLauncher.sol` itself (e.g., minimizing storage writes, efficient loops).
+
+**Phase 3: Major Architectural Improvement (Highest Impact)**
+
+*   [ ] **Task 5: Implement EIP-1167 Clone Factory Pattern:**
+    *   **Sub-task 5.1:** Add OpenZeppelin Contracts dependency if not already present (`npm install @openzeppelin/contracts` or `forge install OpenZeppelin/openzeppelin-contracts`).
+    *   **Sub-task 5.2:** Import `Clones` library: `import "@openzeppelin/contracts/proxy/Clones.sol";` in `NFTLaunchManager.sol`.
+    *   **Sub-task 5.3:** Add a state variable in `NFTLaunchManager` to store the address of the master `NFTLauncher` implementation: `address public nftLauncherImplementation;`.
+    *   **Sub-task 5.4:** Set the `nftLauncherImplementation` address. This could be done:
+        *   In the `NFTLaunchManager` constructor (deploy the implementation first, pass address).
+        *   Through a separate setter function (e.g., `setNFTLauncherImplementation(address _implementation)`) callable by the owner.
+    *   **Sub-task 5.5:** Modify `deployNFT` function:
+        *   Replace `NFTLauncher nftLauncher = new NFTLauncher(...)` with `address clone = Clones.clone(nftLauncherImplementation);`.
+        *   You'll need a way to initialize the clone with `_name`, `_ticker`, and the specific `baseURI` if the `NFTLauncher` constructor requires them. This often involves:
+            *   Changing `NFTLauncher`'s constructor to an `initialize` function.
+            *   Calling this `initialize` function on the `clone` address immediately after cloning: `NFTLauncher(clone).initialize(_name, _ticker, _calculateBaseURI(...));`.
+            *   Ensure the `initialize` function has appropriate access control (e.g., can only be called once).
+        *   Use the `clone` address where `address(nftLauncher)` was previously used (for storing in mappings, emitting events).
+    *   **Sub-task 5.6:** Review `NFTLauncher.sol` to ensure it's compatible with being an implementation contract (e.g., use initializers if needed, avoid `msg.sender` in constructor if logic depends on the *deployer* of the clone).
+
+**Phase 4: Alternative Architecture (Evaluation)**
+
+*   [ ] **Task 6: Evaluate Shared Contract / Registry Model:**
+    *   Consider if replacing individual contract deployments with managing collections within a single, shared NFT contract is a viable alternative for your specific use case.
+    *   Analyze the trade-offs: drastically lower "deployment" cost vs. increased complexity in the manager/shared contract and loss of distinct contract addresses per collection. Decide if this fits your project goals.
+
+This list should help you track your progress on optimizing the `deployNFT` function's gas cost. Remember to test gas consumption after each significant change!

--- a/packages/smartcontract/docs/02_EIP-1167_Implementation_Approach.md
+++ b/packages/smartcontract/docs/02_EIP-1167_Implementation_Approach.md
@@ -1,0 +1,151 @@
+Okay, let's break down the steps to implement EIP-1167 (Minimal Proxy Standard) for your `NFTLauncher` deployment within `NFTLaunchManager`.
+
+The core idea is:
+1.  Deploy the `NFTLauncher` contract *once* to serve as the master implementation.
+2.  Modify `NFTLaunchManager` to deploy cheap "clones" (EIP-1167 proxies) of this master implementation instead of deploying the full `NFTLauncher` bytecode each time.
+3.  Since clones don't run constructors, convert `NFTLauncher`'s constructor logic into an `initialize` function.
+
+---
+
+**Step-by-Step Task List:**
+
+**Phase 1: Modify `NFTLauncher.sol` to be Cloneable**
+
+1.  **Make it Initializable:** Clones cannot use constructors. You need to move the constructor logic into a public initializer function and protect it from being called multiple times. OpenZeppelin's `Initializable` contract is perfect for this.
+    *   **Task:** Import and inherit `Initializable`.
+    *   **Task:** Remove the `constructor`.
+    *   **Task:** Create an `initialize` function that takes the same parameters as the old constructor (`_name`, `_ticker`, `_baseURIInput`) plus an `_initialOwner` parameter.
+    *   **Task:** Call the initializer functions of the inherited contracts (`ERC721`, `Ownable`) within your new `initialize` function using their `__ContractName_init` methods.
+    *   **Task:** Move the logic `i_BaseURI = _baseURIInput;` into the `initialize` function.
+    *   **Task:** Add the `initializer` modifier (from `Initializable`) to your `initialize` function to prevent re-initialization.
+
+    ```diff
+    --- a/packages/smartcontract/src/NFTLauncher.sol
+    +++ b/packages/smartcontract/src/NFTLauncher.sol
+    @@ -1,19 +1,25 @@
+     // SPDX-License-Identifier: MIT
+     pragma solidity ^0.8.28;
+    
+    +import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol"; // Use upgradeable version for init
+     import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+     import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+     import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+    
+    -contract NFTLauncher is ERC721, Ownable {
+    +// Inherit from Initializable
+    +contract NFTLauncher is Initializable, ERC721, Ownable {
+         using Strings for uint256;
+    
+         string private i_BaseURI;
+    -    uint256 private _tokenId = 0;
+    +    uint256 private _tokenId = 0; // Start token ID at 0
+    
+    -    constructor(
+    -        string memory _name,
+    -        string memory _ticker,
+    +    // --- CONSTRUCTOR REMOVED ---
+    +    // Use empty constructor for Initializable pattern if needed for deployment
+    +    // constructor() initializer {} // Not strictly needed if deploying directly once
+    +
+    +    // --- INITIALIZER FUNCTION ---
+    +    function initialize(
+    +        string memory _name, // NFT Name
+    +        string memory _ticker, // NFT Ticker
+         string memory _baseURIInput
+     ) ERC721(_name, _ticker) Ownable(msg.sender) {
+         i_BaseURI = _baseURIInput;
+    @@ -21,10 +27,17 @@
+ 
+     function _baseURI() internal view override returns (string memory) {
+         return i_BaseURI;
+    +        address _initialOwner // The owner of this specific clone
+    +    ) public initializer { // Add initializer modifier
+    +    // Call initializers of parent contracts
+    +    __ERC721_init(_name, _ticker);
+    +    __Ownable_init(_initialOwner); // Set the owner of the clone
+    +
+    +    // Custom initialization logic
+    +    i_BaseURI = _baseURIInput;
+     }
+ 
+     function safeMintTo(address to) public onlyOwner {
+         _safeMint(to, _tokenId);
+    -
+         _tokenId++;
+     }
+    +
+    +    // Gap required by OZ UUPS (though not strictly needed here, good practice)
+    +    // uint256[49] private __gap; // If using UUPS upgradeability, otherwise optional
+    }
+    ```
+
+    *   **Code:** (Implement the changes shown in the diff above in `packages/smartcontract/src/NFTLauncher.sol`)
+    *   **Reference:** OpenZeppelin Initializable: [https://docs.openzeppelin.com/contracts/4.x/upgradeable#initializers](https://docs.openzeppelin.com/contracts/4.x/upgradeable#initializers)
+
+2.  **Install Upgradeable Contracts (if needed):** The `Initializable` contract is often part of the upgradeable contracts package.
+    *   **Task:** If you haven't already, install the OpenZeppelin upgradeable contracts package. Assuming you use npm/yarn in your project structure:
+        ```bash
+        npm install @openzeppelin/contracts-upgradeable
+        # or
+        yarn add @openzeppelin/contracts-upgradeable
+        ```
+    *   **Tool:** Use the `builtin_run_terminal_command` tool.
+
+**Phase 2: Modify `NFTLaunchManager.sol` to Deploy Clones**
+
+3.  **Store Implementation Address:** The manager needs to know the address of the single, deployed `NFTLauncher` implementation.
+    *   **Task:** Add an `immutable` state variable `i_nftLauncherImplementation` of type `address`. Immutable variables are set in the constructor and are cheaper than regular storage variables.
+    *   **Task:** Update the `NFTLaunchManager` constructor to accept the implementation address and store it in `i_nftLauncherImplementation`.
+
+4.  **Use Cloning Library:** Import OpenZeppelin's `Clones` library for creating EIP-1167 proxies.
+    *   **Task:** Import `Clones` from `@openzeppelin/contracts/proxy/Clones.sol`.
+
+5.  **Modify `deployNFT` Function:** Change this function to deploy a clone and then initialize it.
+    *   **Task:** Remove the `new NFTLauncher(...)` line.
+    *   **Task:** Keep the logic for calculating the `baseURI` using `_userContractAmount`.
+    *   **Task:** Use `Clones.clone(i_nftLauncherImplementation)` to deploy the minimal proxy contract. Store the address of the newly created clone.
+    *   **Task:** Call the `initialize` function on the *new clone's address*. Pass the required parameters: `_name`, `_ticker`, the calculated `baseURI`, and critically, `msg.sender` as the `_initialOwner` so the *deployer* owns the new NFT contract, not the manager.
+    *   **Task:** Update the manager's state (`_userContracts`, `_userContractAmount`, `_contractOwner`) using the *clone's address*.
+    *   **Task:** Emit the `DeployNFT` event with the *clone's address*.
+    *   **Task:** Return the *clone's address*.
+
+    ```diff
+    --- a/packages/smartcontract/src/NFTLaunchManager.sol
+    +++ b/packages/smartcontract/src/NFTLaunchManager.sol
+    @@ -3,6 +3,7 @@
+     
+     import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+     import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+    +import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
+     import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+     
+     import {NFTLauncher} from "./NFTLauncher.sol";
+    @@ -18,6 +19,9 @@
+ 
+     string constant NFT_BASE_URI = "https://launchpad-dev.sokushuu.dev/api/nft/";
+ 
+    +    // Address of the single NFTLauncher implementation contract
+    +    address public immutable i_nftLauncherImplementation;
+    +
+     // NFT created by an address
+     mapping(address owner => address[]) private _userContracts;
+ 
+    @@ -43,7 +47,11 @@
+ 
+     error ErrorNFTLaunchManager__PaymentTransferFailed();
+ 
+    -    constructor(address initialOwner) Ownable(initialOwner) {}
+    +    constructor(
+    +        address initialOwner,
+    +        address nftLauncherImplementation_ // Address of the deployed NFTLauncher logic contract
+    +    ) Ownable(initialOwner) {
+    +        i_nftLauncherImplementation = nftLauncherImplementation_;
+    +    }
+ 
+     modifier onlyContractOwner(address contractAddress) {
+         if (msg.sender != _contractOwner[contractAddress]) {
+    @@ -67,25 +75,30 @@
+     }
+ 
+     function deployNFT(string memory _name, string memory _ticker) public returns (address) {
+    +        // --- EIP-116

--- a/packages/smartcontract/docs/03_EIP-1167-Implementation-on-NFTLaunchManager.md
+++ b/packages/smartcontract/docs/03_EIP-1167-Implementation-on-NFTLaunchManager.md
@@ -1,0 +1,109 @@
+Okay, let's modify the `NFTLaunchManager.deployNFT` function to use EIP-1167 clones with your `Initializable` `NFTLauncher`.
+
+You'll need to:
+
+1.  Use `Clones.clone()` to deploy a minimal proxy pointing to the `i_nftLauncherImplementation` address.
+2.  Call the `initialize` function on the newly created clone address.
+3.  **Important:** Modify `NFTLauncher.initialize` to accept the initial owner as an argument, because when the `NFTLaunchManager` calls `initialize`, `msg.sender` within that call context will be the `NFTLaunchManager` itself, not the user calling `deployNFT`.
+
+**Step 1: Modify `NFTLauncher.initialize`**
+
+Change the `initialize` function in `NFTLauncher.sol` to accept the owner:
+
+```solidity
+// packages/smartcontract/src/NFTLauncher.sol
+// ... (imports remain the same)
+
+contract NFTLauncher is Initializable, ERC721Upgradeable, OwnableUpgradeable {
+    using Strings for uint256;
+
+    string private i_BaseURI;
+    uint256 private _tokenId = 0;
+
+    constructor() initializer {} // Keep this constructor
+
+    function initialize(
+        string memory _name,
+        string memory _ticker,
+        string memory _baseURIInput,
+        address initialOwner // <-- Add this parameter
+    ) public initializer {
+        __ERC721_init(_name, _ticker);
+        __Ownable_init(initialOwner); // <-- Use the parameter here
+        i_BaseURI = _baseURIInput;
+    }
+
+    function _baseURI() internal view override returns (string memory) {
+        return i_BaseURI;
+    }
+
+    function safeMintTo(address to) public onlyOwner {
+        // onlyOwner check now correctly refers to 'initialOwner' passed during initialization
+        _safeMint(to, _tokenId);
+        _tokenId++;
+    }
+}
+```
+
+**Step 2: Modify `NFTLaunchManager.deployNFT`**
+
+Update the `deployNFT` function in `NFTLaunchManager.sol` as follows:
+
+```solidity
+// packages/smartcontract/src/NFTLaunchManager.sol
+// ... (imports and other parts of the contract remain the same)
+
+contract NFTLaunchManager is Ownable {
+    // ... (existing state variables, events, errors, constructor, modifiers)
+
+    function deployNFT(string memory _name, string memory _ticker) public returns (address) {
+        // 1. Calculate necessary values
+        uint256 currentAmount = _userContractAmount[msg.sender];
+        string memory baseURI = string.concat(
+            NFT_BASE_URI,
+            "/",
+            (currentAmount + 1).toString(),
+            "/"
+        );
+
+        // 2. Deploy the clone using Clones.clone
+        // Ensure i_nftLauncherImplementation holds the address of a deployed NFTLauncher contract
+        address cloneAddress = Clones.clone(i_nftLauncherImplementation);
+
+        // 3. Initialize the newly deployed clone
+        // We cast the cloneAddress to NFTLauncher to call its functions
+        // We pass msg.sender (the user calling deployNFT) as the initial owner
+        NFTLauncher(cloneAddress).initialize(_name, _ticker, baseURI, msg.sender);
+
+        // 4. Update state using the clone's address
+        _userContracts[msg.sender].push(cloneAddress);
+        _userContractAmount[msg.sender] = currentAmount + 1;
+        _contractOwner[cloneAddress] = msg.sender; // Store the user as the owner in the manager
+
+        // 5. Emit event with the clone's address
+        emit DeployNFT(msg.sender, cloneAddress);
+
+        // 6. Return the clone's address
+        return cloneAddress;
+    }
+
+    // ... (rest of the functions: mintContractTo, listTokenToSell, etc.)
+    // Note: mintContractTo's onlyContractOwner modifier should still work correctly
+    // as _contractOwner[nftContract] is set correctly during deployment.
+    // The onlyOwner check within NFTLauncher.safeMintTo will now correctly
+    // check against the 'initialOwner' set during initialize.
+}
+```
+
+**Explanation of Changes:**
+
+1.  **Removed `new NFTLauncher(...)`:** The direct deployment is gone.
+2.  **`Clones.clone(i_nftLauncherImplementation)`:** This deploys a minimal proxy contract whose logic is delegated to the `i_nftLauncherImplementation` address. This is much cheaper gas-wise than deploying the full contract each time.
+3.  **`NFTLauncher(cloneAddress).initialize(...)`:** We get an instance of the `NFTLauncher` interface pointing at the `cloneAddress` and call its `initialize` function. This sets up the state (name, ticker, base URI, *and owner*) specifically for this clone. Crucially, we pass `msg.sender` (the user initiating the deployment) as the `initialOwner`.
+4.  **State Updates:** All mappings (`_userContracts`, `_userContractAmount`, `_contractOwner`) and the event emission now use the `cloneAddress`.
+
+**Before Deploying `NFTLaunchManager`:**
+
+*   You must first deploy the modified `NFTLauncher.sol` contract *once*.
+*   Take the address of that deployed `NFTLauncher` contract.
+*   Pass that address as the `_nftLauncherImplementation` argument when deploying your `NFTLaunchManager` contract.

--- a/packages/smartcontract/foundry.toml
+++ b/packages/smartcontract/foundry.toml
@@ -6,6 +6,8 @@ remappings = [
     "@openzeppelin/contracts/=dependencies/@openzeppelin-contracts-5.3.0/",
     "forge-std/=dependencies/forge-std-1.9.6/src/",
 ]
+optimizer=true
+optimizer_runs=200
 
 [dependencies]
 forge-std = "1.9.6"

--- a/packages/smartcontract/foundry.toml
+++ b/packages/smartcontract/foundry.toml
@@ -3,6 +3,7 @@ src = "src"
 out = "out"
 libs = ["dependencies"]
 remappings = [
+    "@openzeppelin/contracts-upgradeable/=dependencies/@openzeppelin-contracts-upgradeable-5.3.0/",
     "@openzeppelin/contracts/=dependencies/@openzeppelin-contracts-5.3.0/",
     "forge-std/=dependencies/forge-std-1.9.6/src/",
 ]
@@ -12,6 +13,7 @@ optimizer_runs=200
 [dependencies]
 forge-std = "1.9.6"
 "@openzeppelin-contracts" = "5.3.0"
+"@openzeppelin-contracts-upgradeable" = "5.3.0"
 
 [soldeer]
 remappings_generate = true

--- a/packages/smartcontract/script/NFTLaunchManager.s.sol
+++ b/packages/smartcontract/script/NFTLaunchManager.s.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.28;
 
 import {Script} from "forge-std/Script.sol";
 import {NFTLaunchManager} from "../src/NFTLaunchManager.sol";
+import {NFTLauncher} from "../src/NFTLauncher.sol";
 
 contract NFTLaunchManagerScript is Script {
     NFTLaunchManager public nftLaunchManager;
@@ -13,8 +14,12 @@ contract NFTLaunchManagerScript is Script {
         vm.createSelectFork("pharos-devnet");
 
         vm.startBroadcast();
+
+        NFTLauncher nftLauncher = new NFTLauncher();
+
         nftLaunchManager = new NFTLaunchManager(
-            address(this)
+            address(this),
+            address(nftLauncher)
         );
         vm.stopBroadcast();
     }

--- a/packages/smartcontract/script/NFTLauncher.s.sol
+++ b/packages/smartcontract/script/NFTLauncher.s.sol
@@ -13,11 +13,7 @@ contract NFTLauncherScript is Script {
         vm.createSelectFork("pharos-devnet");
 
         vm.startBroadcast();
-        nftLauncher = new NFTLauncher(
-            "Test NFT Launch",
-            "TNL",
-            "https://launchpad-dev.sokushuu.de/api/nft/test/"
-        );
+        nftLauncher = new NFTLauncher();
         vm.stopBroadcast();
     }
 }

--- a/packages/smartcontract/soldeer.lock
+++ b/packages/smartcontract/soldeer.lock
@@ -6,6 +6,13 @@ checksum = "fa2bc3db351137c4d5eb32b738a814a541b78e87fbcbfeca825e189c4c787153"
 integrity = "d69addf252dfe0688dcd893a7821cbee2421f8ce53d95ca0845a59530043cfd1"
 
 [[dependencies]]
+name = "@openzeppelin-contracts-upgradeable"
+version = "5.3.0"
+url = "https://soldeer-revisions.s3.amazonaws.com/@openzeppelin-contracts-upgradeable/5_3_0_10-04-2025_10:51:56_contracts-upgradeable.zip"
+checksum = "4bd92f87af0cac7226b12ce367e7327f13431735fa6010508d8c8177f9d3d10f"
+integrity = "fa195a69ef4dfec7fec7fbbb77f424258c821832fdd355b0a6e5fe34d2986a16"
+
+[[dependencies]]
 name = "forge-std"
 version = "1.9.6"
 url = "https://soldeer-revisions.s3.amazonaws.com/forge-std/1_9_6_01-02-2025_20:49:10_forge-std-1.9.zip"

--- a/packages/smartcontract/src/NFTLaunchManager.sol
+++ b/packages/smartcontract/src/NFTLaunchManager.sol
@@ -71,24 +71,21 @@ contract NFTLaunchManager is Ownable {
     }
 
     function deployNFT(string memory _name, string memory _ticker) public returns (address) {
-        uint256 amountContractOwned = _getUserContractAmount(msg.sender);
+        uint256 currentAmount = _userContractAmount[msg.sender];
 
         NFTLauncher nftLauncher = new NFTLauncher(
             _name,
             _ticker,
             string.concat(
                 NFT_BASE_URI,
-                amountContractOwned.toString(),
+                "/",
+                (currentAmount + 1).toString(),
                 "/"
             )
         );
 
-        if (_userContracts[msg.sender].length == 0) {
-            _userContracts[msg.sender] = new address[](0);
-        }
-
         _userContracts[msg.sender].push(address(nftLauncher));
-        _userContractAmount[msg.sender] += 1;
+        _userContractAmount[msg.sender] = currentAmount + 1;
         _contractOwner[address(nftLauncher)] = msg.sender;
 
         emit DeployNFT(msg.sender, address(nftLauncher));

--- a/packages/smartcontract/src/NFTLauncher.sol
+++ b/packages/smartcontract/src/NFTLauncher.sol
@@ -1,21 +1,27 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {ERC721Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
 
-contract NFTLauncher is ERC721, Ownable {
+contract NFTLauncher is Initializable, ERC721Upgradeable, OwnableUpgradeable {
     using Strings for uint256;   
 
     string private i_BaseURI;
     uint256 private _tokenId = 0;
 
-    constructor(
+    constructor() initializer {}
+
+    function initialize(
         string memory _name,
         string memory _ticker,
-        string memory _baseURIInput
-    ) ERC721(_name, _ticker) Ownable(msg.sender) {
+        string memory _baseURIInput,
+        address initialOwner
+    ) public initializer {
+        __ERC721_init(_name, _ticker);
+        __Ownable_init(initialOwner);
         i_BaseURI = _baseURIInput;
     }
 
@@ -25,7 +31,6 @@ contract NFTLauncher is ERC721, Ownable {
 
     function safeMintTo(address to) public onlyOwner {
         _safeMint(to, _tokenId);
-
         _tokenId++;
     }
 }

--- a/packages/smartcontract/test/NFTLaunchManager.t.sol
+++ b/packages/smartcontract/test/NFTLaunchManager.t.sol
@@ -19,8 +19,10 @@ contract NFTLaunchManagerTest is Test {
         vm.deal(bob, 10 ether);
 
         vm.prank(deployer);
+        NFTLauncher nftLauncher = new NFTLauncher();
         nftLaunchManager = new NFTLaunchManager(
-            address(this)
+            address(this),
+            address(nftLauncher)
         );
         vm.stopPrank();
     }
@@ -31,12 +33,13 @@ contract NFTLaunchManagerTest is Test {
 
         vm.startPrank(alice);
         address nftAddress = nftLaunchManager.deployNFT(nftName, nftTicker);
+        NFTLauncher nftLauncher = NFTLauncher(nftAddress);
         vm.stopPrank();
 
-        NFTLauncher nftLauncher = NFTLauncher(nftAddress);
 
         assertEq(nftLauncher.name(), nftName);
         assertEq(nftLauncher.symbol(), nftTicker);
+        assertEq(nftLauncher.owner(), address(nftLaunchManager));
         assertEq(nftLaunchManager.getContractOwner(nftAddress), alice);
     }
 

--- a/packages/smartcontract/test/NFTLauncher.t.sol
+++ b/packages/smartcontract/test/NFTLauncher.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.28;
 
 import {Test} from "forge-std/Test.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
 import {NFTLauncher} from "../src/NFTLauncher.sol";
 
 contract NFTLauncherTest is Test {
@@ -15,16 +16,22 @@ contract NFTLauncherTest is Test {
     string public constant NFT_LAUNCHER_BASE_URL = "TEST_LAUNCH_BASE_URL";
 
     function setUp() public {
-        nftLauncher = new NFTLauncher(
+        NFTLauncher nftLauncherImplementation = new NFTLauncher();
+        address nftLauncherAddress = Clones.clone(address(nftLauncherImplementation));
+        NFTLauncher(nftLauncherAddress).initialize(
             NFT_LAUNCHER_NAME,
             NFT_LAUNCHER_TICKER,
-            NFT_LAUNCHER_BASE_URL
+            NFT_LAUNCHER_BASE_URL,
+            address(this)
         );
+
+        nftLauncher = NFTLauncher(nftLauncherAddress);
     }
 
     function test_SetUp() public view {
         assertEq(nftLauncher.name(), NFT_LAUNCHER_NAME);
         assertEq(nftLauncher.symbol(), NFT_LAUNCHER_TICKER);
+        assertEq(nftLauncher.owner(), address(this));
     }
 
     function test_Mint() public {


### PR DESCRIPTION
closes #8 

some approaches to try to optimize gas for deployNFT function

lists are:

**Task List: Gas Optimization for `NFTLaunchManager.sol`**

**Phase 1: Easy Wins / Good Practices**

*   [ ]  **Task 1: Verify Compiler Optimization Settings:**
    *   Check your framework's configuration (e.g., `hardhat.config.js`, `foundry.toml`).
    *   Ensure the Solidity optimizer is enabled.
    *   Ensure the `runs` parameter is set to a reasonable value (e.g., 200 or higher).
*   [ ] **Task 2: Remove Redundant Array Check in `deployNFT`:**
    *   Locate the `if (_userContracts[msg.sender].length == 0)` block in `deployNFT`.
    *   Remove this `if` statement entirely. The `push` operation handles empty arrays correctly.
*   [ ] **Task 3 (Optional - Minor Impact): Cache Storage Read in `deployNFT`:**
    *   In `deployNFT`, read `_userContractAmount[msg.sender]` into a local `uint256 currentAmount` variable at the beginning.
    *   Use `currentAmount` in the `string.concat` call.
    *   Update the amount using `_userContractAmount[msg.sender] = currentAmount + 1;`.

**Phase 2: Contract-Level Optimization**

*   [ ] **Task 4: Analyze and Optimize `NFTLauncher.sol`:**
    *   Review the code within `NFTLauncher.sol`.
    *   Identify and remove any unused functions, variables, or inherited contracts.
    *   Simplify logic within the `NFTLauncher` constructor.
    *   Look for general gas optimizations within `NFTLauncher.sol` itself (e.g., minimizing storage writes, efficient loops).

**Phase 3: Major Architectural Improvement (Highest Impact)**

*   [ ] **Task 5: Implement EIP-1167 Clone Factory Pattern:**
    *   **Sub-task 5.1:** Add OpenZeppelin Contracts dependency if not already present (`npm install @openzeppelin/contracts` or `forge install OpenZeppelin/openzeppelin-contracts`).
    *   **Sub-task 5.2:** Import `Clones` library: `import "@openzeppelin/contracts/proxy/Clones.sol";` in `NFTLaunchManager.sol`.
    *   **Sub-task 5.3:** Add a state variable in `NFTLaunchManager` to store the address of the master `NFTLauncher` implementation: `address public nftLauncherImplementation;`.
    *   **Sub-task 5.4:** Set the `nftLauncherImplementation` address. This could be done:
        *   In the `NFTLaunchManager` constructor (deploy the implementation first, pass address).
        *   Through a separate setter function (e.g., `setNFTLauncherImplementation(address _implementation)`) callable by the owner.
    *   **Sub-task 5.5:** Modify `deployNFT` function:
        *   Replace `NFTLauncher nftLauncher = new NFTLauncher(...)` with `address clone = Clones.clone(nftLauncherImplementation);`.
        *   You'll need a way to initialize the clone with `_name`, `_ticker`, and the specific `baseURI` if the `NFTLauncher` constructor requires them. This often involves:
            *   Changing `NFTLauncher`'s constructor to an `initialize` function.
            *   Calling this `initialize` function on the `clone` address immediately after cloning: `NFTLauncher(clone).initialize(_name, _ticker, _calculateBaseURI(...));`.
            *   Ensure the `initialize` function has appropriate access control (e.g., can only be called once).
        *   Use the `clone` address where `address(nftLauncher)` was previously used (for storing in mappings, emitting events).
    *   **Sub-task 5.6:** Review `NFTLauncher.sol` to ensure it's compatible with being an implementation contract (e.g., use initializers if needed, avoid `msg.sender` in constructor if logic depends on the *deployer* of the clone).

**Phase 4: Alternative Architecture (Evaluation)**

*   [ ] **Task 6: Evaluate Shared Contract / Registry Model:**
    *   Consider if replacing individual contract deployments with managing collections within a single, shared NFT contract is a viable alternative for your specific use case.
    *   Analyze the trade-offs: drastically lower "deployment" cost vs. increased complexity in the manager/shared contract and loss of distinct contract addresses per collection. Decide if this fits your project goals.